### PR TITLE
global debug flag

### DIFF
--- a/plugin/autoclose.vim
+++ b/plugin/autoclose.vim
@@ -8,10 +8,8 @@
 " Last modified: 02/02/2011
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
-let s:debug = 1
-
 " check if script is already loaded
-if s:debug == 0 && exists("g:loaded_AutoClose")
+if !exists("g:debug_AutoClose") && exists("g:loaded_AutoClose")
     finish "stop loading the script"
 endif
 let g:loaded_AutoClose = 1


### PR DESCRIPTION
this way debug mode can be switched on/off externally and we don't commit / release it inadvertently as has happened in the past.
