### PR TITLE
Don't delete random pairs of characters

### DIFF
--- a/plugin/autoclose.vim
+++ b/plugin/autoclose.vim
@@ -50,7 +50,7 @@ function! s:IsEmptyPair()
     if l:prev == "\0" || l:next == "\0"
         return 0
     endif
-    return (l:prev == l:next) || (get(b:AutoClosePairs, l:prev, "\0") == l:next)
+    return get(b:AutoClosePairs, l:prev, "\0") == l:next
 endfunction
 
 function! s:GetCurrentSyntaxRegion()


### PR DESCRIPTION
If hitting backspace between two identical characters that aren't pairs
don't do smart deletion (or rather be smart and only delete one).

This should close issue #8, it is actually a one-line version of a pull request 8 from juhasz.
