### PR TITLE
Fixed AutoClose#DefaultPairs to not throw errors on startup.

### DIFF
--- a/plugin/AutoClose.vim
+++ b/plugin/AutoClose.vim
@@ -317,7 +317,7 @@ endfunction
 
 " this function is made visible for the sake of users
 function! AutoClose#DefaultPairs()
-    return AutoClose#ParsePairs("() {} [] <> `` \"\" ''")
+    return AutoClose#ParsePairs("() {} [] <> ` \" '")
 endfunction
 
 function! AutoClose#DefaultPairsModified(pairsToAdd,openersToRemove)

--- a/plugin/AutoClose.vim
+++ b/plugin/AutoClose.vim
@@ -317,7 +317,7 @@ endfunction
 
 " this function is made visible for the sake of users
 function! AutoClose#DefaultPairs()
-    return AutoClose#ParsePairs("() {} [] <> «» ` \" '")
+    return AutoClose#ParsePairs("() {} [] <> `` \"\" ''")
 endfunction
 
 function! AutoClose#DefaultPairsModified(pairsToAdd,openersToRemove)


### PR DESCRIPTION
When loading the plugin from an xterm-256 terminal in OS X, there were a series of errors being returned before vim would start up. I tracked this down to a series of bad pairs in AutoClose#DefaultPairs and removed / fixed the troublesome pairs.
