### PR TITLE
Use xnoremap for visual mode mappings

### DIFF
--- a/plugin/AutoClose.vim
+++ b/plugin/AutoClose.vim
@@ -370,9 +370,9 @@ function! s:CreatePairsMaps()
         let quoted_opener = s:quoteAndEscape(opener)
         let quoted_closer = s:quoteAndEscape(closer)
 
-        exec "vnoremap <buffer> <silent> ". b:AutoCloseSelectionWrapPrefix
+        exec "xnoremap <buffer> <silent> ". b:AutoCloseSelectionWrapPrefix
                     \ . opener . " <Esc>`>a" . closer .  "<Esc>`<i" . opener . "<Esc>"
-        exec "vnoremap <buffer> <silent> ". b:AutoCloseSelectionWrapPrefix
+        exec "xnoremap <buffer> <silent> ". b:AutoCloseSelectionWrapPrefix
                     \ . closer . " <Esc>`>a" . closer .  "<Esc>`<i" . opener . "<Esc>"
         if key == b:AutoClosePairs[key]
             exec "inoremap <buffer> <silent> " . opener


### PR DESCRIPTION
Hi!

As you know, AutoClose uses vnoremap for the actions that wrap the visual selection. However, vnoremap maps _both_ visual and select modes. Select mode is not very well known, but is very useful for snippets plugins. The Vim documentation advises against mapping printable characters in select mode (see :h Select-mode-mapping or :h mapmode-x) because it might confuse the user. In my case is causing me a conflict with the plugin UltiSnips.

This simple change fixes this.
Thank you!
