### PR TITLE
Expand whitespace

### DIFF
--- a/plugin/AutoClose.vim
+++ b/plugin/AutoClose.vim
@@ -277,6 +277,15 @@ function! s:Backspace()
     return "\<BS>"
 endfunction
 
+function! s:Space()
+    if b:AutoCloseOn && s:IsEmptyPair()
+        call s:PushBuffer("\<Space>")
+        return "\<Space>\<Space>\<Left>"
+    else
+        return "\<Space>"
+    endif
+endfunction
+
 function! s:ToggleAutoClose()
     let b:AutoCloseOn = !b:AutoCloseOn
     if b:AutoCloseOn
@@ -337,6 +346,7 @@ function! s:DefineVariables()
                 \ 'AutoCloseOn': 1,
                 \ 'AutoClosePreservDotReg': 1,
                 \ 'AutoCloseSelectionWrapPrefix': '<LEADER>a',
+                \ 'AutoCloseExpandSpace': 1,
                 \ }
 
     " Let the user define if he/she wants the plugin to do special actions when the
@@ -390,6 +400,9 @@ function! s:CreateExtraMaps()
     " Extra mapping
     inoremap <buffer> <silent> <BS>         <C-R>=<SID>Backspace()<CR>
     inoremap <buffer> <silent> <Del>        <C-R>=<SID>Delete()<CR>
+    if b:AutoCloseExpandSpace
+        inoremap <buffer> <silent> <Space>      <C-R>=<SID>Space()<CR>
+    endif
 
     if b:AutoClosePreservDotReg == 1
         " Fix the re-do feature by flushing the char buffer on key movements (including Escape):

--- a/plugin/AutoClose.vim
+++ b/plugin/AutoClose.vim
@@ -49,14 +49,11 @@ function! s:GetPrevChar()
 endfunction
 
 " used to implement automatic deletion of closing character when opening
-" counterpart is deleted
+" counterpart is deleted and by space expansion
 function! s:IsEmptyPair()
     let l:prev = s:GetPrevChar()
     let l:next = s:GetNextChar()
-    if l:prev == "\0" || l:next == "\0"
-        return 0
-    endif
-    return get(b:AutoClosePairs, l:prev, "\0") == l:next
+    return (l:next != "\0") && (get(b:AutoClosePairs, l:prev, "\0") == l:next)
 endfunction
 
 function! s:GetCurrentSyntaxRegion()
@@ -286,6 +283,14 @@ function! s:Space()
     endif
 endfunction
 
+function! s:Enter()
+    if b:AutoCloseOn && s:IsEmptyPair() && stridx( b:AutoCloseExpandEnterOn, s:GetPrevChar() ) >= 0
+        return "\<CR>\<Esc>O"
+    else
+        return "\<CR>"
+    endif
+endfunction
+
 function! s:ToggleAutoClose()
     let b:AutoCloseOn = !b:AutoCloseOn
     if b:AutoCloseOn
@@ -347,6 +352,7 @@ function! s:DefineVariables()
                 \ 'AutoClosePreservDotReg': 1,
                 \ 'AutoCloseSelectionWrapPrefix': '<LEADER>a',
                 \ 'AutoCloseExpandSpace': 1,
+                \ 'AutoCloseExpandEnterOn': "{",
                 \ }
 
     " Let the user define if he/she wants the plugin to do special actions when the
@@ -402,6 +408,9 @@ function! s:CreateExtraMaps()
     inoremap <buffer> <silent> <Del>        <C-R>=<SID>Delete()<CR>
     if b:AutoCloseExpandSpace
         inoremap <buffer> <silent> <Space>      <C-R>=<SID>Space()<CR>
+    endif
+    if len(b:AutoCloseExpandEnterOn) > 0
+        inoremap <buffer> <silent> <CR>      <C-R>=<SID>Enter()<CR>
     endif
 
     if b:AutoClosePreservDotReg == 1


### PR DESCRIPTION
This isn't finished yet, but just to let it be known that I'm working on it (e.g. for the sake of #17).
This expands space to double space and enter to { double-enter, back and indent }. 
Still to do:
- make it off by default
- make the configuration uniform (for each whitespace list inside which pairs it should be expanded)
- document
