### PR TITLE
[Git] Ignore the doc/tags directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 # File types to be ignored by our git repositories
 
-.DS_Store
-
+doc/tags


### PR DESCRIPTION
Hi Thiago,

The auto-generated doc/tags directory should be ignored. If someone clones your plugin as a Git submodule, it won't say "modified: .vim/pathogen/autoclose (untracked content)" anymore when VIM has produced the helptags for your plugin. I also removed .DS_Store from the ignore list, because every developer should have it included in their own, global ignore list.

Cheers,

Alex
