### PR TITLE
Close popup menu on Esc: do not feed ^E for Esc

### DIFF
--- a/plugin/AutoClose.vim
+++ b/plugin/AutoClose.vim
@@ -370,7 +370,7 @@ function! s:DefineVariables()
                 \ 'AutoCloseSmartQuote': 1,
                 \ 'AutoCloseOn': 1,
                 \ 'AutoCloseSelectionWrapPrefix': '<LEADER>a',
-                \ 'AutoClosePumvisible': {"ENTER": "\<C-Y>", "ESC": "\<C-E>"},
+                \ 'AutoClosePumvisible': {"ENTER": "\<C-Y>", "ESC": "\<ESC>"},
                 \ 'AutoCloseExpandEnterOn': "",
                 \ 'AutoCloseExpandSpace': 1,
                 \ }


### PR DESCRIPTION
complete_CTRL-E is different from Escape in the popup menu; Escape is
meant to close it, while CTRL-E will leave you in insert mode.
