### PR TITLE
Add option to remove before-close characters

### DIFF
--- a/doc/AutoClose.txt
+++ b/doc/AutoClose.txt
@@ -34,6 +34,7 @@ will not insert the closing character for you.
        3.2 Defining protected regions          |ac_protectedregions|
        3.3 Turning AutoClose on and off        |ac_turnon|
        3.4 Selection wrap prefix               |ac_wrapPrefix|
+       3.5 Not closing in ahead of characters  |ac_donotclose|
     4. Under the hood                          |ac_details|
        4.1 Mappings                            |ac_mappings|
 
@@ -254,6 +255,16 @@ want to do that task:
     3. AutoCloseToggle
 
     And if you don't want to map anything, just use them on the command mode.
+
+                                   *ac_donotclose* *AutoCloseDoNotCloseBefore*
+3.5 Not closing in ahead of characters
+
+    You may explicitly define a set of characters to never close in front of.
+By default, these characters are defined as " and '. Example:
+
+>
+    let g:AutoCloseDoNotCloseBefore = "()"
+<
 
                                   *ac_wrapPrefix* *AutoCloseSelectionWrapPrefix*
 

--- a/plugin/AutoClose.vim
+++ b/plugin/AutoClose.vim
@@ -222,6 +222,7 @@ function! s:InsertPair(opener)
     let l:next = s:GetNextChar()
     " only add closing pair before space or any of the closepair chars
     let close_before = '\s\|\V\[,.;' . escape(join(keys(b:AutoClosePairs) + values(b:AutoClosePairs), ''), ']').']'
+    let close_before = substitute(close_before, '[' . b:AutoCloseDoNotCloseBefore . ']', '', 'g')
     if (l:next == "\0" || l:next =~ close_before) && s:AllowQuote(a:opener, 0)
         call s:InsertStringAtCursor(b:AutoClosePairs[a:opener])
         call s:PushBuffer(b:AutoClosePairs[a:opener])
@@ -373,6 +374,7 @@ function! s:DefineVariables()
                 \ 'AutoClosePumvisible': {"ENTER": "\<C-Y>", "ESC": "\<C-E>"},
                 \ 'AutoCloseExpandEnterOn': "",
                 \ 'AutoCloseExpandSpace': 1,
+                \ 'AutoCloseDoNotCloseBefore': "'\"",
                 \ }
 
     " Let the user define if he/she wants the plugin to do special actions when the


### PR DESCRIPTION
4c4902f7196ee3ef0049a705fe93cc91cc0d4d6a improved the on deciding when to close a pair. The choice that closing pairs is OK before any `b:AutoClosePairs` value means that pairs will close ahead of strings. For example, putting `(` in front of `"` gets you `()"` instead of `("`.

`AutoCloseDoNotCloseBefore` allows setting an explicit set of characters to never close in front of.
