### PR TITLE
Fix issues of autoclosing single and double quotes when using certain color schemes

### DIFF
--- a/plugin/AutoClose.vim
+++ b/plugin/AutoClose.vim
@@ -366,7 +366,7 @@ function! s:DefineVariables()
     " The buffer namespace is used internally
     let defaults = {
                 \ 'AutoClosePairs': AutoClose#DefaultPairs(),
-                \ 'AutoCloseProtectedRegions': ["Comment", "String", "Character"],
+                \ 'AutoCloseProtectedRegions': ["Comment"],
                 \ 'AutoCloseSmartQuote': 1,
                 \ 'AutoCloseOn': 1,
                 \ 'AutoCloseSelectionWrapPrefix': '<LEADER>a',


### PR DESCRIPTION
If the used color scheme redefines the 'String' or 'Character' syntax regions, autoclosing single and double quotes stops working (see issues #43, #45, #55, and #64) . This PR fixes this problem and supposedly solve the issues mentioned.

(Anyway, why would you disable autoclosing in strings?)
