### PR TITLE
Inserting an abbreviation expand keystroke before space.

### DIFF
--- a/plugin/AutoClose.vim
+++ b/plugin/AutoClose.vim
@@ -454,7 +454,7 @@ function! s:CreateExtraMaps()
     inoremap <buffer> <silent> <BS>         <C-R>=<SID>Backspace()<CR>
     inoremap <buffer> <silent> <Del>        <C-R>=<SID>Delete()<CR>
     if b:AutoCloseExpandSpace
-        inoremap <buffer> <silent> <Space>      <C-R>=<SID>Space()<CR>
+        inoremap <buffer> <silent> <Space>      <C-]><C-R>=<SID>Space()<CR>
     endif
     if len(b:AutoCloseExpandEnterOn) > 0
         inoremap <buffer> <silent> <CR>      <C-R>=<SID>Enter()<CR>


### PR DESCRIPTION
Abbreviations don't expand on space with this plugin on, since it remaps space.

Let's just add the zero-width keystroke for abbreviation expansion before we do our crazy space work :)
